### PR TITLE
Adds a variable to control our own mapping creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,20 @@ vim-resize
 
 ## Usage
 * use the arrow keys in normal mode to resize a vertical or horizontal split in the desired direction
+
+## Configuration
+
+### Mappings
+
+By default, this plugin uses these mappings:
+
+    nnoremap <silent> <c-left> :CmdResizeLeft<cr>
+    nnoremap <silent> <c-down> :CmdResizeDown<cr>
+    nnoremap <silent> <c-up> :CmdResizeUp<cr>
+    nnoremap <silent> <c-right> :CmdResizeRight<cr>
+
+If you want to set your own mappings, do:
+
+    let g:vim_resize_disable_auto_mappings = 1
+
+and then set your mappings in your ~/.vimrc file.

--- a/plugin/resize.vim
+++ b/plugin/resize.vim
@@ -105,7 +105,9 @@ command! CmdResizeDown call <SID>ResizeDown(v:count)
 command! CmdResizeUp call <SID>ResizeUp(v:count)
 command! CmdResizeRight call <SID>ResizeRight(v:count)
 
-nnoremap <silent> <c-left> :CmdResizeLeft<cr>
-nnoremap <silent> <c-down> :CmdResizeDown<cr>
-nnoremap <silent> <c-up> :CmdResizeUp<cr>
-nnoremap <silent> <c-right> :CmdResizeRight<cr>
+if get(g:, 'vim_resize_disable_auto_mappings') == 0
+    nnoremap <silent> <c-left> :CmdResizeLeft<cr>
+    nnoremap <silent> <c-down> :CmdResizeDown<cr>
+    nnoremap <silent> <c-up> :CmdResizeUp<cr>
+    nnoremap <silent> <c-right> :CmdResizeRight<cr>
+endif


### PR DESCRIPTION
I'm using this plugin for several months, but it suddendly stopped working
on my last pull. The c-left, c-right, c-down, c-up mappings don't
work on my terminal vim (using gnome-terminal and vim 7.4.796).

This pull request solves this issues by allowing to user to disable automatic
mappings and create his own.
