### PR TITLE
Allow user to specify g:resize_count

### DIFF
--- a/plugin/resize.vim
+++ b/plugin/resize.vim
@@ -3,7 +3,10 @@
 " Version:      1.0
 
 " Globals
-let g:resize_count = 1
+if !exists('g:resize_count')
+    let g:resize_count = 1
+endif
+
 
 "Is<direction>Most Boolean Functions
 function! IsRightMost()


### PR DESCRIPTION
Currently, the plugin overrides `g:resize_count` to 1, regardless of what the user sets it to